### PR TITLE
Fix copying constants with long value

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -840,9 +840,9 @@ func (g *Generator) copyConst(c *types.Const) error {
 		default:
 			typeName = t.Name()
 		}
-		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), typeName, c.Val().String())
+		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), typeName, c.Val().ExactString())
 	default:
-		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), g.TypeOf(t), c.Val().String())
+		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), g.TypeOf(t), c.Val().ExactString())
 	}
 
 	return err

--- a/generator.go
+++ b/generator.go
@@ -831,19 +831,26 @@ func (g *Generator) CopyVal(vSpec *ast.ValueSpec) error {
 }
 
 func (g *Generator) copyConst(c *types.Const) error {
-	var err error
+	var typeName string
+	val := c.Val().String()
+
 	switch t := c.Type().(type) {
 	case *types.Basic:
-		var typeName string
 		switch t.Kind() {
-		case types.UntypedBool, types.UntypedInt, types.UntypedRune, types.UntypedFloat, types.UntypedComplex, types.UntypedString, types.UntypedNil:
+		case types.UntypedString:
+			val = c.Val().ExactString()
+		case types.String:
+			val = c.Val().ExactString()
+			typeName = t.Name()
+		case types.UntypedBool, types.UntypedInt, types.UntypedRune, types.UntypedFloat, types.UntypedComplex, types.UntypedNil:
 		default:
 			typeName = t.Name()
 		}
-		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), typeName, c.Val().ExactString())
 	default:
-		_, err = fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), g.TypeOf(t), c.Val().ExactString())
+		typeName = g.TypeOf(t)
 	}
+
+	_, err := fmt.Fprintf(g, "const %s %s = %s\n", c.Name(), typeName, val)
 
 	return err
 }


### PR DESCRIPTION
`String()` cuts string with length greater than 72 and adds `...` at the end.